### PR TITLE
Update on task comment widget and screen capture

### DIFF
--- a/qtazu/widgets/comment.py
+++ b/qtazu/widgets/comment.py
@@ -69,14 +69,11 @@ class DragDropLabel(ClickableLabel):
 
 class CommentWidget(QtWidgets.QDialog):
     """A CG-Wire comment widget
-
     This includes the ability to take Screenshots from the widget
     by default, to disable use `set_allow_screenshot(False)`
-
     If you are using this Widget in another interface that has its
     own submit button then use `set_button_visibility(False)` and
     trigger `submit()` from your surrounding widget.
-
     """
 
     StatusRole = QtCore.Qt.UserRole + 1
@@ -210,10 +207,8 @@ class CommentWidget(QtWidgets.QDialog):
 
     def set_thumbnail_visible(self, value):
         """Set thumbnail visibility
-
         Disabling this also implicitly disables the screenshot feature
         since screenshotting is only possible by clicking the thumbnail.
-
         """
         self.thumbnail_label.setVisible(value)
         self.thumbnail.setVisible(value)
@@ -225,11 +220,9 @@ class CommentWidget(QtWidgets.QDialog):
 
     def set_attachment(self, path):
         """Set the attachment.
-
         Args:
             path (str): This should be a valid path that can be
                 used as preview attachment for the comment.
-
         """
         assert os.path.exists(path), \
             "Attachment path does not exist: %s" % path
@@ -357,10 +350,7 @@ class CommentWidget(QtWidgets.QDialog):
         comment_text = self.comment.toPlainText()
 
         # Submit comment
-        comment = gazu.task.add_comment(task,
-                                        status,
-                                        comment=comment_text)
-        log.info("Submitted comment: %s", comment)
+        
 
         # Upload preview and attach to comment
         has_preview = bool(self._attachment)
@@ -369,12 +359,19 @@ class CommentWidget(QtWidgets.QDialog):
             assert os.path.exists(filepath), \
                 "File does not exist: %s" % filepath
 
-            preview = gazu.task.add_preview(task, comment, filepath)
-            log.info("Submitted preview: %s", preview)
+            comment = gazu.task.add_comment(task,
+                                        status,
+                                        comment=comment_text,
+                                        attachments=[filepath])
+            log.info("Submitted comment: %s", comment)
 
             # Clear the attachment
             self._attachment = None
-
+        else:
+            comment = gazu.task.add_comment(task,
+                                        status,
+                                        comment=comment_text)
+        log.info("Submitted comment: %s", comment)
         if self._close_on_submit:
             # Close after submission for now to avoid confusion
             # todo: if not closing add message that submission succeeded

--- a/qtazu/widgets/screenmarquee.py
+++ b/qtazu/widgets/screenmarquee.py
@@ -3,6 +3,7 @@ import sys
 import os
 
 from Qt import QtCore, QtGui, QtWidgets
+from PyQt5.QtGui import QPixmap, QScreen
 
 
 class ScreenMarquee(QtWidgets.QDialog):
@@ -128,7 +129,10 @@ class ScreenMarquee(QtWidgets.QDialog):
         self._fit_screen_geometry()
 
         # Start fade in animation
-        fade_anim = QtCore.QPropertyAnimation(self, b"_opacity_anim_prop", self)
+        property = "_opacity_anim_prop"
+        encoded_property = property.encode()
+        byte_array = bytearray(encoded_property)
+        fade_anim = QtCore.QPropertyAnimation(self, byte_array , self)
         fade_anim.setStartValue(self._opacity)
         fade_anim.setEndValue(50)
         fade_anim.setDuration(200)
@@ -169,8 +173,9 @@ def get_desktop_pixmap(rect):
         QtGui.QPixmap: Captured pixmap image
 
     """
+    screen = QtWidgets.QApplication.primaryScreen()
     desktop = QtWidgets.QApplication.desktop()
-    pixmap = QtGui.QPixmap.grabWindow(desktop.winId(),
+    pixmap = screen.grabWindow(desktop.winId(),
                                       rect.x(),
                                       rect.y(),
                                       rect.width(),


### PR DESCRIPTION
"comment.py" modified : 
Image in attachment was sent as a task preview file ... Which was not logical because it is a comment tool, so the image must be sent as a comment attachment.

"screenmarquee.py" modified : 
QPixmap.grabScreen is deprecated.
QtCore.QPropertyAnimation(self, byte_array , self) second argument must be type byte array.